### PR TITLE
Cake4 php81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.2']
+        php-version: ['8.1', '8.3']
         db-type: [sqlite, mysql, pgsql]
         prefer-lowest: ['']
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             db-type: 'sqlite'
             prefer-lowest: 'prefer-lowest'
 
@@ -67,7 +67,7 @@ jobs:
           if [[ ${{ matrix.db-type }} == 'sqlite' ]]; then export DB_URL='sqlite:///:memory:'; fi
           if [[ ${{ matrix.db-type }} == 'mysql' ]]; then export DB_URL='mysql://root:root@127.0.0.1/cakephp'; fi
           if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then export DB_URL='postgres://postgres:postgres@127.0.0.1/postgres'; fi
-          if [[ ${{ matrix.php-version }} == '7.4' && ${{ matrix.db-type }} == 'sqlite' ]]; then
+          if [[ ${{ matrix.php-version }} == '8.1' && ${{ matrix.db-type }} == 'sqlite' ]]; then
             vendor/bin/phpunit --coverage-clover=coverage.xml
           else
             vendor/bin/phpunit
@@ -76,7 +76,7 @@ jobs:
         run: if ${{ matrix.prefer-lowest == 'prefer-lowest' }}; then vendor/bin/validate-prefer-lowest -m; fi
 
       - name: Code Coverage Report
-        if: success() && matrix.php-version == '7.4' && matrix.db-type == 'sqlite'
+        if: success() && matrix.php-version == '8.1' && matrix.db-type == 'sqlite'
         uses: codecov/codecov-action@v3
 
   validation:
@@ -89,7 +89,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           extensions: mbstring, intl
           coverage: none
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is an alternative to
 
 As value object you have a few advantages, especially on handling the values inside your business logic.
 
-This branch is for use with **CakePHP 4.2+**. See [version map](https://github.com/dereuromark/cakephp-decimal/wiki#cakephp-version-map) for details.
+This branch is for use with **CakePHP 4.4+**. See [version map](https://github.com/dereuromark/cakephp-decimal/wiki#cakephp-version-map) for details.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Stable Version](https://poser.pugx.org/dereuromark/cakephp-decimal/v/stable.svg)](https://packagist.org/packages/dereuromark/cakephp-decimal)
 [![codecov](https://codecov.io/gh/dereuromark/cakephp-decimal/branch/master/graph/badge.svg)](https://codecov.io/gh/dereuromark/cakephp-decimal)
 [![License](https://poser.pugx.org/dereuromark/cakephp-decimal/license)](https://packagist.org/packages/dereuromark/cakephp-decimal)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.4-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 
 This is an alternative to
  * the core Decimal type (using plain strings)
@@ -15,7 +15,7 @@ This branch is for use with **CakePHP 4.2+**. See [version map](https://github.c
 
 ## Requirements
 
-- Uses [spryker/decimal-object](https://github.com/spryker/decimal-object) and as such requires bcmath extension.
+- Uses [php-collective/decimal-object](https://github.com/php-collective/decimal-object) and as such requires bcmath extension.
 
 ## Installation
 Require the plugin through Composer:
@@ -23,85 +23,8 @@ Require the plugin through Composer:
 composer require dereuromark/cakephp-decimal
 ```
 
-## Usage
+## Setup and Usage
+See [Documentation](docs/).
 
-To enable this for all your decimal columns, use this in bootstrap:
-```php
-Type::map('decimal', 'CakeDecimal\Database\Type\DecimalObjectType');
- ```
-
-This will automatically replace the core behavior and map any incoming value to the value object on marshalling,
-and also convert your database values to it when reading.
-
-If you just want to map certain fields, you need to use an alias for those.
-```php
-Type::map('decimal_object', 'CakeDecimal\Database\Type\DecimalObjectType');
- ```
-Then inside your Table classes set them explicitly inside `_initializeSchema()`:
-```php
-/**
- * @param \Cake\Database\Schema\TableSchemaInterface $schema
- *
- * @return \Cake\Database\Schema\TableSchemaInterface
- */
-protected function _initializeSchema(TableSchemaInterface $schema): TableSchemaInterface {
-    $schema->setColumnType('amount', 'decimal_object');
-    ...
-
-    return $schema;
-}
-```
-
-For details on `Decimal` class, see [Decimal value object documentation](https://github.com/spryker/decimal-object/tree/master/docs).
-
-
-## Configuration
-
-You can configure the Type class in your bootstrap.
-
-To enable auto trim:
-```php
-Type::build('decimal')
-    ->useAutoTrim();
-```
-
-To enable localization parsing:
-```php
-Type::build('decimal')
-    ->useLocaleParser();
-```
-
-## Customization
-
-You can extend the value object and use the same config as shown above to enable your custom Decimal VO extension class.
-Your extension can be more strict or less strict.
-
-
-## Templating
-When using PHP templating and NumberHelper methods, it can make sense to extend them locally for better usability.
-```php
-namespace App\View\Helper;
-
-use Cake\View\Helper\NumberHelper as CoreNumberHelper;
-use Spryker\DecimalObject\Decimal;
-
-class NumberHelper extends CoreNumberHelper
-{
-    /**
-     * @param \Spryker\DecimalObject\Decimal|string|float|int $number
-     * @param array<string, mixed> $options
-     *
-     * @return string Formatted number
-     */
-    public function format($number, array $options = []): string
-    {
-        if ($number instanceof Decimal) {
-            $options += ['places' => $number->scale()];
-            $number = (string)$number;
-        }
-
-        return parent::format($number, $options);
-    }
-}
-```
-Pro-tip: The display of the places/precision is now also more correct compared to the default casting to float.
+## Demo
+Live example see https://sandbox.dereuromark.de/sandbox/decimal-examples/forms

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
 	"description": "CakePHP plugin for decimal handling via value object. Provides DecimalType class.",
 	"license": "MIT",
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.1",
 		"cakephp/cakephp": "^4.2",
-		"spryker/decimal-object": "^1.0.1"
+		"php-collective/decimal-object": "^1.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"require": {
 		"php": ">=8.1",
-		"cakephp/cakephp": "^4.2",
+		"cakephp/cakephp": "^4.4.17",
 		"php-collective/decimal-object": "^1.0.0"
 	},
 	"require-dev": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,95 @@
+# CakeDecimal plugin documentation
+
+## Setup
+To enable this for all your decimal columns, use this in bootstrap:
+```php
+TypeFactory::map('decimal', 'CakeDecimal\Database\Type\DecimalObjectType');
+ ```
+
+This will automatically replace the core behavior and map any incoming value to the value object on marshalling,
+and also convert your database values to it when reading.
+
+If you just want to map certain fields, you need to use an alias for those.
+```php
+TypeFactory::map('decimal_object', 'CakeDecimal\Database\Type\DecimalObjectType');
+ ```
+Then inside your Table classes set them explicitly inside `_initializeSchema()`:
+```php
+/**
+ * @param \Cake\Database\Schema\TableSchemaInterface $schema
+ *
+ * @return \Cake\Database\Schema\TableSchemaInterface
+ */
+protected function _initializeSchema(TableSchemaInterface $schema): TableSchemaInterface {
+    $schema->setColumnType('amount', 'decimal_object');
+    ...
+
+    return $schema;
+}
+```
+
+For details on `Decimal` class, see [Decimal value object documentation](https://github.com/php-collective/decimal-object/tree/master/docs).
+
+
+## Configuration
+
+You can configure the Type class in your bootstrap.
+
+To enable auto trim:
+```php
+Type::build('decimal')
+    ->useAutoTrim();
+```
+
+To enable localization parsing:
+```php
+Type::build('decimal')
+    ->useLocaleParser();
+```
+
+## Customization
+
+You can extend the value object and use the same config as shown above to enable your custom Decimal VO extension class.
+Your extension can be more strict or less strict.
+
+
+## Templating
+When using PHP templating and NumberHelper methods, you can use the extended NumberHelper that ships with this plugin.
+```php
+// in your AppView.php
+$this->addHelper('CakeDecimal.Number');
+```
+This will replace the built-in core one.
+
+If you only need a subset or want to further customize, it can make sense to extend the methods locally as helper:
+```php
+namespace App\View\Helper;
+
+use Cake\View\Helper\NumberHelper as CoreNumberHelper;
+use PhpCollective\DecimalObject\Decimal;
+
+class NumberHelper extends CoreNumberHelper {
+
+    /**
+     * @param \PhpCollective\DecimalObject\Decimal|string|float|int $number
+     * @param array<string, mixed> $options
+     *
+     * @return string Formatted number
+     */
+    public function format($number, array $options = []): string
+    {
+        if ($number instanceof Decimal) {
+            $options += ['places' => $number->scale()];
+            $number = (string)$number;
+        }
+
+        return parent::format($number, $options);
+    }
+
+    ...
+
+}
+```
+
+Pro-tip: The display of the places/precision is now also more correct compared to the default casting to float.
+This is due to the Decimal value object storing the DB fields' scale internally up until string conversion on output.

--- a/src/Database/Type/DecimalObjectType.php
+++ b/src/Database/Type/DecimalObjectType.php
@@ -6,8 +6,8 @@ use Cake\Database\DriverInterface;
 use Cake\Database\Type\BaseType;
 use Cake\Database\Type\BatchCastingInterface;
 use PDO;
+use PhpCollective\DecimalObject\Decimal;
 use RuntimeException;
-use Spryker\DecimalObject\Decimal;
 
 /**
  * Decimal type converter using value object.
@@ -16,7 +16,7 @@ use Spryker\DecimalObject\Decimal;
  * and Shim plugin (using string in 3.x just like 4.x will).
  * As value object you have a few advantages, especially on handling the values inside your business logic.
  *
- * @link https://github.com/spryker/decimal
+ * @link https://github.com/php-collective/decimal
  */
 class DecimalObjectType extends BaseType implements BatchCastingInterface {
 
@@ -46,10 +46,10 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 	/**
 	 * Convert integer data into the database format.
 	 *
-	 * @param \Spryker\DecimalObject\Decimal|string|float|int|null $value The value to convert.
+	 * @param \PhpCollective\DecimalObject\Decimal|string|float|int|null $value The value to convert.
 	 * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
 	 * @throws \InvalidArgumentException
-	 * @return \Spryker\DecimalObject\Decimal|null
+	 * @return \PhpCollective\DecimalObject\Decimal|null
 	 */
 	public function toDatabase($value, DriverInterface $driver) {
 		if ($value === null || $value === '') {
@@ -68,7 +68,7 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 	 *
 	 * @param string|float|int|null $value The value to convert.
 	 * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
-	 * @return \Spryker\DecimalObject\Decimal|null
+	 * @return \PhpCollective\DecimalObject\Decimal|null
 	 */
 	public function toPHP($value, DriverInterface $driver) {
 		if ($value === null) {
@@ -115,7 +115,7 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 	 * Marshals request data into PHP Decimal value objects.
 	 *
 	 * @param mixed $value The value to convert.
-	 * @return \Spryker\DecimalObject\Decimal|null Converted value.
+	 * @return \PhpCollective\DecimalObject\Decimal|null Converted value.
 	 */
 	public function marshal($value) {
 		if ($value === null || $value === '') {
@@ -177,7 +177,7 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 	 * aware parser.
 	 *
 	 * @param string $value The value to parse and convert to an float.
-	 * @return \Spryker\DecimalObject\Decimal
+	 * @return \PhpCollective\DecimalObject\Decimal
 	 */
 	protected function _parseValue(string $value): Decimal {
 		/** @var \Cake\I18n\Number $class */

--- a/src/View/Helper/NumberHelper.php
+++ b/src/View/Helper/NumberHelper.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace CakeDecimal\View\Helper;
+
+use Cake\View\Helper\NumberHelper as CoreNumberHelper;
+use PhpCollective\DecimalObject\Decimal;
+
+class NumberHelper extends CoreNumberHelper {
+
+	/**
+	 * @param \PhpCollective\DecimalObject\Decimal|string|float|int $number
+	 * @param array<string, mixed> $options
+	 *
+	 * @return string Formatted number
+	 */
+	public function format($number, array $options = []): string {
+		if ($number instanceof Decimal) {
+			$options += ['places' => $number->scale()];
+			$number = (string)$number;
+		}
+
+		return parent::format($number, $options);
+	}
+
+	/**
+	 * @param \PhpCollective\DecimalObject\Decimal|string|float $number Value to format.
+	 * @param string|null $currency International currency name such as 'USD', 'EUR', 'JPY', 'CAD'
+	 * @param array<string, mixed> $options Options list.
+	 *
+	 * @return string Number formatted as a currency.
+	 */
+	public function currency($number, ?string $currency = null, array $options = []): string {
+		if ($number instanceof Decimal) {
+			$options += ['places' => $number->scale()];
+			$number = (string)$number;
+		}
+
+		return parent::currency($number, $currency, $options);
+	}
+
+	/**
+	 * @param \PhpCollective\DecimalObject\Decimal|string|float $value A floating point number
+	 * @param array<string, mixed> $options Options list.
+	 *
+	 * @return string formatted delta
+	 */
+	public function formatDelta($value, array $options = []): string {
+		if ($value instanceof Decimal) {
+			$options += ['places' => $value->scale()];
+			$value = (string)$value;
+		}
+
+		return parent::formatDelta($value, $options);
+	}
+
+	/**
+	 * @param \PhpCollective\DecimalObject\Decimal|string|float|int $value
+	 * @param int $precision
+	 * @param array $options
+	 *
+	 * @return string Human readable size
+	 */
+	public function precision($value, int $precision = 3, array $options = []): string {
+		if ($value instanceof Decimal) {
+			$options += ['places' => $value->scale()];
+			$value = (string)$value;
+		}
+
+		return parent::precision($value, $precision, $options);
+	}
+
+	/**
+	 * @param \PhpCollective\DecimalObject\Decimal|string|float|int $value A floating point number
+	 * @param int $precision The precision of the returned number
+	 * @param array<string, mixed> $options Options
+	 *
+	 * @return string Percentage string
+	 */
+	public function toPercentage($value, int $precision = 2, array $options = []): string {
+		if ($value instanceof Decimal) {
+			$value = (string)$value;
+			$options += ['multiply' => true];
+		}
+
+		return parent::toPercentage($value, $precision, $options);
+	}
+
+}

--- a/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
@@ -3,13 +3,13 @@
 namespace CakeDecimal\Test\TestCase\Database\Type;
 
 use Cake\Database\DriverInterface;
-use Cake\Database\Type;
+use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
 use Cake\I18n\I18n;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use CakeDecimal\Database\Type\DecimalObjectType;
-use Spryker\DecimalObject\Decimal;
+use PhpCollective\DecimalObject\Decimal;
 use TestApp\Model\Table\DecimalTypesTable;
 use TestApp\Model\Table\FloatTypesTable;
 
@@ -38,7 +38,7 @@ class DecimalObjectTypeTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		Type::map('decimal', DecimalObjectType::class);
+		TypeFactory::map('decimal', DecimalObjectType::class);
 
 		$this->Table = TableRegistry::get('DecimalTypes', ['className' => DecimalTypesTable::class]);
 	}
@@ -145,7 +145,7 @@ class DecimalObjectTypeTest extends TestCase {
 		]);
 		$this->Table->saveOrFail($record);
 
-		/** @var \Spryker\DecimalObject\Decimal $decimal */
+		/** @var \PhpCollective\DecimalObject\Decimal $decimal */
 		$decimal = $record->amount_nullable;
 		$newDecimal = $decimal->subtract($record->amount_required)->subtract($record->amount_required);
 		$record->amount_nullable = $newDecimal;
@@ -195,9 +195,9 @@ class DecimalObjectTypeTest extends TestCase {
 		]);
 		$this->Table->saveOrFail($record);
 
-		/** @var \Spryker\DecimalObject\Decimal $decimal */
+		/** @var \PhpCollective\DecimalObject\Decimal $decimal */
 		$decimal = $record->amount_nullable;
-		$newDecimal = $record->amount_required->add($record->amount_nullable);
+		$newDecimal = $record->amount_required->add($decimal);
 		$record->amount_nullable = $newDecimal;
 
 		$this->Table->saveOrFail($record);

--- a/tests/TestCase/View/Helper/NumberHelperTest.php
+++ b/tests/TestCase/View/Helper/NumberHelperTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace CakeDecimal\Test\TestCase\View\Helper;
+
+use Cake\TestSuite\TestCase;
+use Cake\View\View;
+use CakeDecimal\View\Helper\NumberHelper;
+use PhpCollective\DecimalObject\Decimal;
+
+class NumberHelperTest extends TestCase {
+
+	/**
+	 * @var \CakeDecimal\View\Helper\NumberHelper
+	 */
+	protected $Number;
+
+	/**
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->Number = new NumberHelper(new View());
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		unset($this->Number);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFormat(): void {
+		$string = '12.123';
+		$result = $this->Number->format(Decimal::create($string));
+		$this->assertSame($string, $result);
+	}
+
+	/**
+	 * On some systems there is a whitespace between the symbol and the value.
+	 *
+	 * @return void
+	 */
+	public function testCurrency(): void {
+		$string = '12.13';
+
+		$result = $this->Number->currency(Decimal::create($string));
+		$this->assertTextContains('$', $result);
+		$this->assertTextContains('12.13', $result);
+
+		$result = $this->Number->currency(Decimal::create($string), 'EUR');
+		$this->assertTextContains('€', $result);
+		$this->assertTextContains('12.13', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testFormatDelta(): void {
+		$string = '12.13';
+		$result = $this->Number->formatDelta(Decimal::create($string));
+		$this->assertSame('+' . $string, $result);
+
+		$string = '-13.14';
+		$result = $this->Number->formatDelta(Decimal::create($string));
+		$this->assertSame($string, $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testPrecision(): void {
+		$string = '1.234';
+		$result = $this->Number->precision(Decimal::create($string));
+		$this->assertSame('1.234', $result);
+
+		$string = '111.23';
+		$result = $this->Number->precision(Decimal::create($string));
+		$this->assertSame('111.230', $result);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testToPercentage(): void {
+		$string = '0.123';
+		$result = $this->Number->toPercentage(Decimal::create($string));
+		$this->assertSame('12.30%', $result);
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 
 use Cake\Cache\Cache;
 use Cake\Core\Configure;
-use Cake\Database\Type;
+use Cake\Database\TypeFactory;
 use Cake\Datasource\ConnectionManager;
 
 if (!defined('DS')) {
@@ -52,10 +52,10 @@ $cache = [
 	],
 ];
 Cache::setConfig($cache);
-Type::build('time');
-Type::build('date');
-Type::build('datetime');
-Type::build('timestamp');
+TypeFactory::build('time');
+TypeFactory::build('date');
+TypeFactory::build('datetime');
+TypeFactory::build('timestamp');
 
 // Ensure default test connection is defined
 if (!getenv('db_dsn')) {


### PR DESCRIPTION
Can we release a fixed up version for 8.1+?

1.x is Cake4
2.x is already Cake5
There is no major version in between, but this PR would kind of require a major usually.

This would be disruptive and somewhat breaking if pulled by accident, as it now uses the new library (maintained version).
I wonder if there is a way besides documention..

Maybe a conflict composer.json entry?

We could also add class_alias() for the value object as well as the type class.
That should also then safely allow the upgrade?

Any feedback welcome.

This of course is only an issue for those already on 8.1+. The ones on 7.4/8.0 cannot pull this anyway.