### PR TITLE
Preserve precision when marshalling locale-formatted strings

### DIFF
--- a/src/Database/Type/DecimalObjectType.php
+++ b/src/Database/Type/DecimalObjectType.php
@@ -5,6 +5,7 @@ namespace CakeDecimal\Database\Type;
 use Cake\Database\Driver;
 use Cake\Database\Type\BaseType;
 use Cake\Database\Type\BatchCastingInterface;
+use NumberFormatter;
 use PDO;
 use PhpCollective\DecimalObject\Decimal;
 use RuntimeException;
@@ -127,7 +128,7 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 		if (is_numeric($value)) {
 			return Decimal::create($value);
 		}
-		if (is_string($value) && preg_match('/^[0-9,. ]+$/', $value)) {
+		if (is_string($value) && preg_match('/^-?[0-9]+(?:\.[0-9]+)?$/', $value)) {
 			return Decimal::create($value);
 		}
 		if ($value instanceof Decimal) {
@@ -173,17 +174,42 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 	}
 
 	/**
-	 * Converts a string into a float point after parsing it using the locale
-	 * aware parser.
+	 * Converts a locale-formatted string into a Decimal value object.
 	 *
-	 * @param string $value The value to parse and convert to an float.
+	 * Locale parsing is performed without a float intermediate so the full
+	 * precision of the input string is preserved. The active locale's
+	 * grouping separator is stripped and its decimal separator is replaced
+	 * with `.` so the resulting canonical numeric string can be passed
+	 * directly to Decimal::create().
+	 *
+	 * @param string $value The value to parse and convert to a Decimal.
 	 * @return \PhpCollective\DecimalObject\Decimal
 	 */
 	protected function _parseValue(string $value): Decimal {
 		/** @var \Cake\I18n\Number $class */
 		$class = static::$numberClass;
+		$formatter = $class::formatter();
 
-		return Decimal::create($class::parseFloat($value));
+		$groupingSeparator = $formatter->getSymbol(NumberFormatter::GROUPING_SEPARATOR_SYMBOL);
+		$decimalSeparator = $formatter->getSymbol(NumberFormatter::DECIMAL_SEPARATOR_SYMBOL);
+
+		$canonical = $value;
+		if ($groupingSeparator !== '') {
+			$canonical = str_replace($groupingSeparator, '', $canonical);
+		}
+		if ($decimalSeparator !== '' && $decimalSeparator !== '.') {
+			$canonical = str_replace($decimalSeparator, '.', $canonical);
+		}
+		$canonical = trim($canonical);
+
+		if ($canonical === '' || !is_numeric($canonical)) {
+			// Fall back to NumberFormatter parsing when canonicalization fails
+			// (e.g. exotic locales). This still loses precision, but matches
+			// the historical behavior for unrecognized inputs.
+			return Decimal::create($class::parseFloat($value));
+		}
+
+		return Decimal::create($canonical);
 	}
 
 }

--- a/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
@@ -274,7 +274,66 @@ class DecimalObjectTypeTest extends TestCase {
 		$result = $type->marshal($value);
 		I18n::setLocale($locale);
 
-		$this->assertSame('12.121', (string)$result);
+		// Trailing zeros are preserved — the locale parser must not route
+		// values through a float intermediate that silently strips them.
+		$this->assertSame('12.1210', (string)$result);
+	}
+
+	/**
+	 * Locale-aware marshalling must preserve full precision and not route
+	 * the value through a float intermediate (which would silently truncate
+	 * the input to ~15 significant decimal digits).
+	 *
+	 * @return void
+	 */
+	public function testUseLocaleParserPreservesPrecision(): void {
+		$type = new DecimalObjectType();
+		$type->useLocaleParser();
+
+		$locale = I18n::getLocale();
+		I18n::setLocale('de_DE');
+		try {
+			// 30 fractional digits — far beyond float precision.
+			$result = $type->marshal('0,000000000000000000000000000001');
+			$this->assertInstanceOf(Decimal::class, $result);
+			$this->assertSame('0.000000000000000000000000000001', (string)$result);
+
+			// Grouping separator (.) plus decimal separator (,) for de_DE.
+			$result = $type->marshal('1.234.567,890123456789012345');
+			$this->assertInstanceOf(Decimal::class, $result);
+			$this->assertSame('1234567.890123456789012345', (string)$result);
+		} finally {
+			I18n::setLocale($locale);
+		}
+
+		// And for an en_US-style input where decimal separator is `.`.
+		I18n::setLocale('en_US');
+		try {
+			$result = $type->marshal('1,234,567.890123456789012345');
+			$this->assertInstanceOf(Decimal::class, $result);
+			$this->assertSame('1234567.890123456789012345', (string)$result);
+		} finally {
+			I18n::setLocale($locale);
+		}
+	}
+
+	/**
+	 * Without the locale parser, ambiguous group-separator strings must not
+	 * be silently accepted — Decimal::create() would throw on them, surfacing
+	 * as a runtime error far from the input source.
+	 *
+	 * @return void
+	 */
+	public function testMarshalRejectsAmbiguousGroupedString(): void {
+		$type = new DecimalObjectType();
+
+		$this->assertNull($type->marshal('1,234.56'));
+		$this->assertNull($type->marshal('1.234,56'));
+		$this->assertNull($type->marshal('1 234.56'));
+
+		// Plain canonical decimals still pass through.
+		$this->assertSame('1234.56', (string)$type->marshal('1234.56'));
+		$this->assertSame('-1234.56', (string)$type->marshal('-1234.56'));
 	}
 	/**
 	 * @return void


### PR DESCRIPTION
## Summary

- `DecimalObjectType::_parseValue()` was routing locale-parsed strings through `Cake\I18n\Number::parseFloat()` and constructing the `Decimal` from the resulting `float`. That silently truncated input to ~15 significant decimal digits — the exact failure mode the plugin exists to avoid. Replace the active locale's grouping/decimal separators inline so a canonical numeric string is handed straight to `Decimal::create()` with no float intermediate.
- Tighten the `marshal()` fall-through regex from `/^[0-9,. ]+$/` to a strict canonical decimal pattern. The previous regex accepted ambiguous strings like `'1,234.56'` even when the locale parser was off, which then threw an `InvalidArgumentException` inside `Decimal::create()` far from the input source.
- Add regression tests covering 30-digit fractional precision through the locale parser, grouped de_DE / en_US inputs, and rejection of ambiguous grouped strings when the locale parser is off. Updated `testUseLocalParser` to assert the precision-preserving result `'12.1210'` (the prior `'12.121'` only passed because the float intermediate stripped the trailing zero).
