### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Database/Type/DecimalObjectType.php
+++ b/src/Database/Type/DecimalObjectType.php
@@ -128,7 +128,7 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 		if (is_numeric($value)) {
 			return Decimal::create($value);
 		}
-		if (is_string($value) && preg_match('/^-?[0-9]+(?:\.[0-9]+)?$/', $value)) {
+		if (is_string($value) && preg_match('/^-?\d+(?:\.\d+)?$/', $value)) {
 			return Decimal::create($value);
 		}
 		if ($value instanceof Decimal) {

--- a/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
@@ -381,7 +381,7 @@ class DecimalObjectTypeTest extends TestCase {
 	protected function isConnection(string $driver): bool {
 		$config = ConnectionManager::getConfig('test');
 
-		return str_contains((string) $config['driver'], $driver);
+		return str_contains((string)$config['driver'], $driver);
 	}
 
 	/**

--- a/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
+++ b/tests/TestCase/Database/Type/DecimalObjectTypeTest.php
@@ -381,7 +381,7 @@ class DecimalObjectTypeTest extends TestCase {
 	protected function isConnection(string $driver): bool {
 		$config = ConnectionManager::getConfig('test');
 
-		return str_contains($config['driver'], $driver);
+		return str_contains((string) $config['driver'], $driver);
 	}
 
 	/**

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -21,7 +21,7 @@ foreach ($iterator as $file) {
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
 
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.