### PR TITLE
Fix PHPStan on CakePHP 5.4

### DIFF
--- a/src/Database/Type/DecimalObjectType.php
+++ b/src/Database/Type/DecimalObjectType.php
@@ -206,7 +206,12 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 			// Fall back to NumberFormatter parsing when canonicalization fails
 			// (e.g. exotic locales). This still loses precision, but matches
 			// the historical behavior for unrecognized inputs.
-			return Decimal::create($class::parseFloat($value) ?? $value);
+			$parsed = $formatter->parse($value, NumberFormatter::TYPE_DOUBLE);
+			if ($parsed === false) {
+				return Decimal::create($value);
+			}
+
+			return Decimal::create($parsed);
 		}
 
 		return Decimal::create($canonical);

--- a/src/Database/Type/DecimalObjectType.php
+++ b/src/Database/Type/DecimalObjectType.php
@@ -183,9 +183,9 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 	 * directly to Decimal::create().
 	 *
 	 * @param string $value The value to parse and convert to a Decimal.
-	 * @return \PhpCollective\DecimalObject\Decimal
+	 * @return \PhpCollective\DecimalObject\Decimal|null
 	 */
-	protected function _parseValue(string $value): Decimal {
+	protected function _parseValue(string $value): ?Decimal {
 		/** @var \Cake\I18n\Number $class */
 		$class = static::$numberClass;
 		$formatter = $class::formatter();
@@ -206,7 +206,12 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 			// Fall back to NumberFormatter parsing when canonicalization fails
 			// (e.g. exotic locales). This still loses precision, but matches
 			// the historical behavior for unrecognized inputs.
-			return Decimal::create($class::parseFloat($value));
+			$parsed = $class::parseFloat($value);
+			if ($parsed === null) {
+				return null;
+			}
+
+			return Decimal::create($parsed);
 		}
 
 		return Decimal::create($canonical);

--- a/src/Database/Type/DecimalObjectType.php
+++ b/src/Database/Type/DecimalObjectType.php
@@ -206,12 +206,7 @@ class DecimalObjectType extends BaseType implements BatchCastingInterface {
 			// Fall back to NumberFormatter parsing when canonicalization fails
 			// (e.g. exotic locales). This still loses precision, but matches
 			// the historical behavior for unrecognized inputs.
-			$parsed = $class::parseFloat($value);
-			if ($parsed === null) {
-				return null;
-			}
-
-			return Decimal::create($parsed);
+			return Decimal::create($class::parseFloat($value) ?? $value);
 		}
 
 		return Decimal::create($canonical);


### PR DESCRIPTION
Fixes PHPStan findings surfaced with CakePHP 5.4.0-RC2.\n\nVerified locally with CakePHP 5.4.0-RC2:\n- composer stan\n- composer cs-check\n- composer test